### PR TITLE
Fixed event shorthand deprecation issues

### DIFF
--- a/js/et_re_ajax.js
+++ b/js/et_re_ajax.js
@@ -21,8 +21,8 @@ function p_delete(text){
 	});
 }
 
-jQuery(document).ready(function($){
-	$("#form2").submit(function(){
+jQuery(function($){
+	$("#form2").on("submit", function(){
 		$('#et_re_loading2').show();
 		$('#et_re_sv_search').attr('disabled', true);
 		data = $("#form2").serialize()+'&do=customize_advanced_search&action=update_et_options&etre_nonce='+etre_vars.etre_nonce;
@@ -36,7 +36,7 @@ jQuery(document).ready(function($){
 		
 		return false;
 	});
-	$("#form1").submit(function(){
+	$("#form1").on("submit", function(){
 		$('#et_re_loading').show();
 		$('#et_re_submit').attr('disabled', true);
 		data = $("#form1").serialize()+'&do=update_et_options&action=update_et_options&etre_nonce='+etre_vars.etre_nonce;
@@ -51,7 +51,7 @@ jQuery(document).ready(function($){
 		return false;
 	});
 	
-	jQuery("#add_property_type_submit").click(function(){
+	jQuery("#add_property_type_submit").on("click", function(){
 		if( jQuery("#property_type_text").val()==""){
 			jQuery(".ajxrsp").html('Enter Property Type.').fadeIn();
 		} else {

--- a/js/jquery.flexslider.js
+++ b/js/jquery.flexslider.js
@@ -87,7 +87,7 @@
 
         // KEYBOARD:
         if (vars.keyboard && ($(slider.containerSelector).length === 1 || vars.multipleKeyboard)) {
-          $(document).bind('keyup', function(event) {
+          $(document).on('keyup', function(event) {
             var keycode = event.keyCode;
             if (!slider.animating && (keycode === 39 || keycode === 37)) {
               var target = (keycode === 39) ? slider.getTarget('next') :
@@ -98,7 +98,7 @@
         }
         // MOUSEWHEEL:
         if (vars.mousewheel) {
-          slider.bind('mousewheel', function(event, delta, deltaX, deltaY) {
+          slider.on('mousewheel', function(event, delta, deltaX, deltaY) {
             event.preventDefault();
             var target = (delta < 0) ? slider.getTarget('next') : slider.getTarget('prev');
             slider.flexAnimate(target, vars.pauseOnAction);
@@ -125,7 +125,7 @@
         if (touch && vars.touch) methods.touch();
 
         // FADE&&SMOOTHHEIGHT || SLIDE:
-        if (!fade || (fade && vars.smoothHeight)) $(window).bind("resize focus", methods.resize);
+        if (!fade || (fade && vars.smoothHeight)) $(window).on("resize focus", methods.resize);
 
 
         // API: start() Callback
@@ -139,7 +139,7 @@
           slider.animatingTo = Math.floor(slider.currentSlide/slider.move);
           slider.currentItem = slider.currentSlide;
           slider.slides.removeClass(namespace + "active-slide").eq(slider.currentItem).addClass(namespace + "active-slide");
-          slider.slides.click(function(e){
+          slider.slides.on("click", function(e){
             e.preventDefault();
             var $slide = $(this),
                 target = $slide.index();
@@ -251,14 +251,14 @@
 
           methods.directionNav.update();
 
-          slider.directionNav.bind(eventType, function(event) {
+          slider.directionNav.on(eventType, function(event) {
             event.preventDefault();
             var target = ($(this).hasClass(namespace + 'next')) ? slider.getTarget('next') : slider.getTarget('prev');
             slider.flexAnimate(target, vars.pauseOnAction);
           });
           // Prevent iOS click event bug
           if (touch) {
-            slider.directionNav.bind("click touchstart", function(event) {
+            slider.directionNav.on("click touchstart", function(event) {
               event.preventDefault();
             });
           }
@@ -295,7 +295,7 @@
 
           methods.pausePlay.update((vars.slideshow) ? namespace + 'pause' : namespace + 'play');
 
-          slider.pausePlay.bind(eventType, function(event) {
+          slider.pausePlay.on(eventType, function(event) {
             event.preventDefault();
             if ($(this).hasClass(namespace + 'pause')) {
               slider.manualPause = true;
@@ -309,7 +309,7 @@
           });
           // Prevent iOS click event bug
           if (touch) {
-            slider.pausePlay.bind("click touchstart", function(event) {
+            slider.pausePlay.on("click touchstart", function(event) {
               event.preventDefault();
             });
           }
@@ -507,7 +507,7 @@
               slider.currentSlide = slider.animatingTo;
             }
             slider.container.unbind("webkitTransitionEnd transitionend");
-            slider.container.bind("webkitTransitionEnd transitionend", function() {
+            slider.container.on("webkitTransitionEnd transitionend", function() {
               slider.wrapup(dimension);
             });
           } else {
@@ -524,7 +524,7 @@
             slider.slides.eq(target).css({ "opacity": 1, "zIndex": 2 });
 
             slider.slides.unbind("webkitTransitionEnd transitionend");
-            slider.slides.eq(slider.currentSlide).bind("webkitTransitionEnd transitionend", function() {
+            slider.slides.eq(slider.currentSlide).on("webkitTransitionEnd transitionend", function() {
               // API: after() animation Callback
               vars.after(slider);
             });

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === WP Real Estate ===
-Contributors: hozyali, 99robots, charliepatel, draftpress
+Contributors: 99robots, charliepatel, DraftPress
 Donate link: http://www.etechy101.com/wp-real-estate-wordpress-plugin
 Tags: property listing, wp real estate, wordpress real estate plugin, advanced property search
 Requires at least: 4.5
-Tested up to: 5.5.1
-Stable tag: 5.5.2
+Tested up to: 5.7.2
+Stable tag: 5.5.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -97,6 +97,10 @@ Go to Appearance > Widgets and add the text widget in your sidebar. then add thi
 3- Add property screen with great additional options and custom post type for better SE ranking
 
 == Changelog ==
+
+= 5.5.3 = 2021-06-11
+* Updated to make compatible with WordPress 5.7.2
+* Fixed event shorthand deprecation issues
 
 = 5.5.2 = 2020-09-14
 * Updated to make compatible with WordPress 5.5.1

--- a/wprealestate.php
+++ b/wprealestate.php
@@ -1,11 +1,11 @@
 <?php
 /*
   Plugin Name: WP Real Estate
-  Plugin URI: http://www.etechy101.com/wp-real-estate-wordpress-plugin
+  Plugin URI: https://draftpress.com/products/wp-real-estate-wordpress-plugin
   Description: Real estate property listing.
-  Author: 99robots
-  Version: 5.5.2
-  Author URI: https://99robots.com
+  Author: DraftPress
+  Version: 5.5.3
+  Author URI: https://draftpress.com
   Text Domain: wprealestate
   Domain Path: /languages
  */


### PR DESCRIPTION
### Made Compatible with WordPress 5.7.2
### Fixed event shorthand deprecation issue:

changed : `jQuery(document).ready(function($){`  
to:  `jQuery(function($){`

changed `.click(function(){`  
to: `.on('click', function() {`

changed `.bind`
to: `.on`

changed `.submit(function(){`  
to:  `.on( "submit", function(){`
